### PR TITLE
Update HMAService.kt

### DIFF
--- a/xposed/src/main/java/icu/nullptr/hidemyapplist/xposed/HMAService.kt
+++ b/xposed/src/main/java/icu/nullptr/hidemyapplist/xposed/HMAService.kt
@@ -58,7 +58,7 @@ class HMAService(val pms: IPackageManager) : IHMAService.Stub() {
             }
         }
         if (!this::dataDir.isInitialized) {
-            dataDir = "/data/system/hide_my_applist_" + Utils.generateRandomString(16)
+            dataDir = "/data/system/h_m_a_" + Utils.generateRandomString(16)
         }
 
         File("$dataDir/log").mkdirs()


### PR DESCRIPTION
Very stupid detection point - Kotak Neo app detection SDK can scan here and find "hide_my_applist" string in folder name and treat it as suspicious and refuse to open.